### PR TITLE
Fixing SPD to CARLA Stage 1: Removing SendWorkerScreeningResults this…

### DIFF
--- a/spice-carla-sync-service/Controllers/WorkerScreeningsController.cs
+++ b/spice-carla-sync-service/Controllers/WorkerScreeningsController.cs
@@ -50,7 +50,7 @@ namespace Gov.Jag.Spice.CarlaSync.Controllers
             return Ok();
         }       
 
-        /// <summary>
+        /*/// <summary>
         /// Send a completed worker screening to the CARLA system for test purposes.  Normally this would occur from a polling process.
         /// </summary>
         /// <returns></returns>
@@ -66,6 +66,6 @@ namespace Gov.Jag.Spice.CarlaSync.Controllers
             BackgroundJob.Enqueue(() => new CarlaUtils(Configuration, _loggerFactory, _sharepoint).SendWorkerScreeningResult(payload));
             _logger.LogInformation($"Started send Worker Screening result for job: {result.RecordIdentifier}");
             return Ok();
-        }
+        }*/
     }
 }


### PR DESCRIPTION
… is not used by the application and not allowed by OpenApi definitions

- Duplicate Operation '' > 'WorkerScreenings' detected(This is most likely due to 2 operation using the same 'operationId' or 'tags'). Duplicates have those paths:
  - post /api/WorkerScreenings/receive
  - post /api/WorkerScreenings/send