### PR TITLE
SPDCSS-1174: New Screenings Not Merging With Existing Contacts

### DIFF
--- a/spd-ess-portal/Utils/DynamicsUtility.cs
+++ b/spd-ess-portal/Utils/DynamicsUtility.cs
@@ -99,6 +99,7 @@ namespace Gov.Jag.Spice.Public.Utils
                 Lastname = candidate.LastName,
                 SpiceDateofbirth = candidate.DateOfBirth,
                 Emailaddress1 = candidate.Email,
+                SpicePositiontitle = candidate.Position,
             };
 
             entity = await dynamicsClient.Contacts.CreateAsync(entity);


### PR DESCRIPTION
Fixed issue where contacts were being duplicated. This was occurring because the query string to fetch a candidate included a check for spice_positiontitle, but that field was not being saved when candidates were created. Verified locally that contacts are no longer being duplicated.