### PR TITLE
SPDCSS-1192: Outage Message for Security Screening

### DIFF
--- a/spd-ess-portal/ClientApp/src/app/app.component.html
+++ b/spd-ess-portal/ClientApp/src/app/app.component.html
@@ -5,18 +5,23 @@
 
 <div class="app-outer" *ngIf="!isIE10orLower()">
   <header class="app-header">
-    <div class="top-menu row" style="padding-left: 30px; padding-right: 30px; margin:0;">
+    <div
+      class="top-menu row"
+      style="padding-left: 30px; padding-right: 30px; margin: 0"
+    >
       <section class="col-md-8 col-xs-12">
         <a href="http://www2.gov.bc.ca/" tabindex="1">
-          <img class="header-logo" alt="B.C. Government Logo" src="assets/bc-logo.svg">
+          <img
+            class="header-logo"
+            alt="B.C. Government Logo"
+            src="assets/bc-logo.svg"
+          />
         </a>
-        <span class="title" role="banner">
-          Security Programs Division
-        </span>
+        <span class="title" role="banner"> Security Programs Division </span>
       </section>
       <section class="col-md-4 col-xs-12 sign-container">
         <span class="sign" *ngIf="currentUser">
-          <span>{{currentUser.displayName}}</span>
+          <span>{{ currentUser.displayName }}</span>
           &nbsp;
           <span class="text-right signin">
             <a href="logout">Sign Out</a>
@@ -30,27 +35,61 @@
     <div class="app-main">
       <div *ngIf="error" class="text-center">
         <h1>Site Error</h1>
-        <p>{{error}}</p>
+        <p>
+          This site is experiencing unexpected errors. Please check back later.
+        </p>
       </div>
-      <router-outlet *ngIf="!error"></router-outlet>
+      <div
+        *ngIf="!error && configuration?.outageInfo?.isOutage"
+        class="text-center"
+      >
+        <h1>Site Outage</h1>
+        <p>{{ configuration.outageInfo.content }}</p>
+        <p>{{ generateOutageDateMessage() }}</p>
+      </div>
+      <router-outlet
+        *ngIf="!error && !configuration?.outageInfo?.isOutage"
+      ></router-outlet>
     </div>
   </main>
 
   <footer class="app-footer">
-    <nav class="navbar navbar-default navbar-expand navbar-footer navbar-static-bottom">
+    <nav
+      class="navbar navbar-default navbar-expand navbar-footer navbar-static-bottom"
+    >
       <div class="container c1">
         <ul class="navbar-nav">
           <li class="c2">
-            <a href="https://www2.gov.bc.ca/gov/content/home/disclaimer" target="_blank" title="Goes to BC Gov Disclaimer Page">Disclaimer</a>
+            <a
+              href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
+              target="_blank"
+              title="Goes to BC Gov Disclaimer Page"
+              >Disclaimer</a
+            >
           </li>
           <li class="c2">
-            <a href="https://www2.gov.bc.ca/gov/content/home/privacy" target="_blank" title="Goes to BC Gov Privacy Page">Privacy</a>
+            <a
+              href="https://www2.gov.bc.ca/gov/content/home/privacy"
+              target="_blank"
+              title="Goes to BC Gov Privacy Page"
+              >Privacy</a
+            >
           </li>
           <li class="c2">
-            <a href="https://www2.gov.bc.ca/gov/content/home/accessibility" target="_blank" title="Goes to BC Gov Accessibility Page">Accessibility</a>
+            <a
+              href="https://www2.gov.bc.ca/gov/content/home/accessibility"
+              target="_blank"
+              title="Goes to BC Gov Accessibility Page"
+              >Accessibility</a
+            >
           </li>
           <li class="c2">
-            <a href="https://www2.gov.bc.ca/gov/content/home/copyright" target="_blank" title="Goes to BC Gov Copyright Page">Copyright</a>
+            <a
+              href="https://www2.gov.bc.ca/gov/content/home/copyright"
+              target="_blank"
+              title="Goes to BC Gov Copyright Page"
+              >Copyright</a
+            >
           </li>
         </ul>
       </div>

--- a/spd-ess-portal/ClientApp/src/app/app.module.ts
+++ b/spd-ess-portal/ClientApp/src/app/app.module.ts
@@ -43,6 +43,7 @@ import { metaReducers, reducers } from './app-state/reducers/reducers';
 
 import { ScreeningRequestDataService } from './services/screening-request-data.service';
 import { UserDataService } from './services/user-data.service';
+import { ConfigService } from '@appservices/config.service';
 
 import { AppRoutingModule } from './app-routing.module';
 
@@ -156,6 +157,7 @@ import { FileUploaderComponent } from './shared/file-uploader/file-uploader.comp
     ScreeningRequestDataService,
     Title,
     UserDataService,
+    ConfigService,
   ],
   bootstrap: [AppComponent]
 })

--- a/spd-ess-portal/ClientApp/src/app/models/configuration.ts
+++ b/spd-ess-portal/ClientApp/src/app/models/configuration.ts
@@ -1,0 +1,6 @@
+/* tslint:disable */
+/* eslint-disable */
+import { OutageInformation } from './outage-information';
+export interface Configuration {
+  outageInfo?: OutageInformation;
+}

--- a/spd-ess-portal/ClientApp/src/app/models/outage-information.ts
+++ b/spd-ess-portal/ClientApp/src/app/models/outage-information.ts
@@ -1,0 +1,9 @@
+/* tslint:disable */
+/* eslint-disable */
+export interface OutageInformation {
+    isOutage?: boolean;
+    content?: string | null;
+    outageEndDate?: string | null;
+    outageStartDate?: string | null;
+  }
+  

--- a/spd-ess-portal/ClientApp/src/app/services/config.service.ts
+++ b/spd-ess-portal/ClientApp/src/app/services/config.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { DataService } from './data.service';
+import { Configuration } from '@appmodels/configuration';
+
+@Injectable()
+export class ConfigService extends DataService {
+    headers: HttpHeaders = new HttpHeaders({
+        'Content-Type': 'application/json'
+    });
+
+    constructor(private http: HttpClient) {
+        super();
+    }
+
+    public async load(): Promise<Configuration> {
+        const path = `${this.apiPath}/Configuration`;
+        try {
+            return await lastValueFrom(
+                this.http.get<Configuration>(path, { headers: this.headers })
+                    .pipe(catchError(this.handleError))
+            );
+        } catch (error) {
+            this.handleError(error);
+            throw error;
+        }
+    }
+}

--- a/spd-ess-portal/ClientApp/src/app/utilities/datetimeUtility.ts
+++ b/spd-ess-portal/ClientApp/src/app/utilities/datetimeUtility.ts
@@ -1,0 +1,19 @@
+
+export function parseDate(dateString: string): string {
+    console.log("Date String: ", dateString);
+    const date = new Date(dateString);
+  
+    if (isNaN(date.getTime())) {
+      return "Invalid Date";
+    }
+  
+    return date.toLocaleString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true
+    }).replace(" at", "");
+  }
+  

--- a/spd-ess-portal/Controllers/ConfigurationController.cs
+++ b/spd-ess-portal/Controllers/ConfigurationController.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+using Gov.Jag.Spice.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Gov.Jag.Spice.Public.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ConfigurationController : ControllerBase
+    {
+        private readonly ILogger<ConfigurationController> _logger;
+        private readonly IDynamicsClient _dynamicsClient;
+        private readonly IConfiguration _configuration;
+
+        public ConfigurationController(ILogger<ConfigurationController> logger, IDynamicsClient dynamicsClient, IConfiguration configuration)
+        {
+            _logger = logger;
+            _dynamicsClient = dynamicsClient;
+            _configuration = configuration;
+        }
+
+        [AllowAnonymous]
+        [HttpGet]
+        public IActionResult GetConfiguration()
+        {
+            try
+            {
+                // Log to check if the section exists
+                _logger.LogInformation("Configuration section exists: " + _configuration.GetSection("Configuration").Exists());
+
+                // Retrieve the entire Configuration section from appsettings.json
+                var configurationData = _configuration.GetSection("Configuration").Get<ConfigurationRoot>();
+
+                if (configurationData == null)
+                {
+                    _logger.LogWarning("Configuration information is not configured.");
+                    return NotFound("Configuration information not found.");
+                }
+
+                _logger.LogInformation("Full Configuration Information: {@ConfigurationData}", configurationData);
+
+                return new JsonResult(configurationData);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve configuration information.");
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+        }
+    }
+}
+
+public class ConfigurationRoot
+{
+    public OutageInfo OutageInfo { get; set; }
+}
+public class OutageInfo
+{
+    public bool IsOutage { get; set; }
+    public string Content { get; set; }
+    public DateTime OutageStartDate { get; set; }
+    public DateTime OutageEndDate { get; set; }
+}

--- a/spd-ess-portal/appsettings.Development.json
+++ b/spd-ess-portal/appsettings.Development.json
@@ -12,5 +12,14 @@
         "Name": "Console"
       }
     ]
+  },
+
+  "Configuration": {
+    "OutageInfo": {
+      "IsOutage": false,
+      "Content": "The system is currently experiencing an outage.",
+      "OutageStartDate": "2024-01-01T00:00:00Z",
+      "OutageEndDate": "2024-01-01T00:00:00Z"
+    }
   }
 }

--- a/spd-ess-portal/appsettings.Staging.json
+++ b/spd-ess-portal/appsettings.Staging.json
@@ -10,8 +10,19 @@
     "WriteTo": [
       {
         "Name": "Console",
-        "Args": { "formatter": "Serilog.Formatting.Elasticsearch.ElasticsearchJsonFormatter, Serilog.Formatting.Elasticsearch" }
+        "Args": {
+          "formatter": "Serilog.Formatting.Elasticsearch.ElasticsearchJsonFormatter, Serilog.Formatting.Elasticsearch"
+        }
       }
     ]
+  },
+
+  "Configuration": {
+    "OutageInfo": {
+      "IsOutage": false,
+      "Content": "The system is currently experiencing an outage.",
+      "OutageStartDate": "2024-01-01T00:00:00Z",
+      "OutageEndDate": "2024-01-01T00:00:00Z"
+    }
   }
 }

--- a/spd-ess-portal/appsettings.json
+++ b/spd-ess-portal/appsettings.json
@@ -5,9 +5,20 @@
       "WriteTo": [
         {
           "Name": "Console",
-          "Args": { "formatter": "Serilog.Formatting.Elasticsearch.ElasticsearchJsonFormatter, Serilog.Formatting.Elasticsearch" } 
+          "Args": {
+            "formatter": "Serilog.Formatting.Elasticsearch.ElasticsearchJsonFormatter, Serilog.Formatting.Elasticsearch"
+          }
         }
       ]
+    }
+  },
+
+  "Configuration": {
+    "OutageInfo": {
+      "IsOutage": false,
+      "Content": "The system is currently experiencing an outage.",
+      "OutageStartDate": "2024-01-01T00:00:00Z",
+      "OutageEndDate": "2024-01-01T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
This change adds a configuration object to AppSettings.json: an adjustable ConfigMap in Openshift that can be adjusted on-the-fly as outages come up. When set up correctly, this will render an outage message instead of the usual application content.

![siteoutagemessage](https://github.com/user-attachments/assets/f7a3a1f7-6fdd-4e3a-b584-0a58e09e0c20)

This message can be configured as follows:

![appsettings](https://github.com/user-attachments/assets/e88cc86b-c338-48a5-b8aa-38c0feb104d6)