### PR TITLE
SDCM-282: Update Dynamics Auth To Support Cloud Auth

### DIFF
--- a/.csharpierrc
+++ b/.csharpierrc
@@ -1,0 +1,4 @@
+printWidth: 120
+useTabs: false
+indentSize: 4
+endOfLine: lf

--- a/interfaces/Dynamics-Autorest/DynamicsAutorest.csproj
+++ b/interfaces/Dynamics-Autorest/DynamicsAutorest.csproj
@@ -1,16 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
-   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-  </ItemGroup>
-
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />
+        <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+        <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    </ItemGroup>
 </Project>

--- a/interfaces/Dynamics-Autorest/Extensions/DynamicsSetupUtil.cs
+++ b/interfaces/Dynamics-Autorest/Extensions/DynamicsSetupUtil.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.Extensions.Configuration;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
 using Newtonsoft.Json;
 
@@ -10,110 +9,169 @@ namespace Gov.Jag.Spice.Interfaces
 {
     public static class DynamicsSetupUtil
     {
-
-        public static ServiceClientCredentials GetServiceClientCredentials(IConfiguration Configuration)
+        /// <summary>
+        /// Retrieves <see cref="ServiceClientCredentials"/> for the Dynamics client using Dataverse (cloud) authentication.
+        /// </summary>
+        /// <param name="Configuration">The application configuration.</param>
+        /// <returns>ServiceClientCredentials, or null if required configuration is missing.</returns>
+        public static ServiceClientCredentials GetDataverseTokenCredentials(IConfiguration Configuration)
         {
-            // Cloud - x.dynamics.com
             string aadTenantId = Configuration["DYNAMICS_AAD_TENANT_ID"]; // Cloud AAD Tenant ID
             string serverAppIdUri = Configuration["DYNAMICS_SERVER_APP_ID_URI"]; // Cloud Server App ID URI
             string appRegistrationClientKey = Configuration["DYNAMICS_APP_REG_CLIENT_KEY"]; // Cloud App Registration Client Key
             string appRegistrationClientId = Configuration["DYNAMICS_APP_REG_CLIENT_ID"]; // Cloud App Registration Client Id
 
-            // One Premise ADFS (2016)
+            if (
+                string.IsNullOrEmpty(appRegistrationClientId)
+                || string.IsNullOrEmpty(appRegistrationClientKey)
+                || string.IsNullOrEmpty(serverAppIdUri)
+                || string.IsNullOrEmpty(aadTenantId)
+            )
+            {
+                return null;
+            }
+
+            var tokenUrl = $"https://login.microsoftonline.com/{aadTenantId}/oauth2/v2.0/token";
+            using var httpClient = new HttpClient();
+            var pairs = new Dictionary<string, string>
+            {
+                { "grant_type", "client_credentials" },
+                { "client_id", appRegistrationClientId },
+                { "client_secret", appRegistrationClientKey },
+                { "scope", $"{serverAppIdUri}/.default" },
+            };
+
+            var content = new FormUrlEncodedContent(pairs);
+            var response = httpClient.PostAsync(tokenUrl, content).Result;
+            var resultContent = response.Content.ReadAsStringAsync().Result;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception($"Dataverse token request failed: {resultContent}");
+            }
+
+            var result = JsonConvert.DeserializeObject<Dictionary<string, object>>(resultContent);
+            string token = result["access_token"].ToString();
+
+            return new TokenCredentials(token);
+        }
+
+        /// <summary>
+        /// Retrieves <see cref="ServiceClientCredentials"/> for the Dynamics client using ADFS 2016 (on-premise) authentication.
+        /// </summary>
+        /// <param name="Configuration">The application configuration.</param>
+        /// <returns>ServiceClientCredentials, or null if required configuration is missing.</returns>
+        public static ServiceClientCredentials GetOnPremTokenCredentials(IConfiguration Configuration)
+        {
             string adfsOauth2Uri = Configuration["ADFS_OAUTH2_URI"]; // ADFS OAUTH2 URI - usually /adfs/oauth2/token on STS
             string applicationGroupResource = Configuration["DYNAMICS_APP_GROUP_RESOURCE"]; // ADFS 2016 Application Group resource (URI)
             string applicationGroupClientId = Configuration["DYNAMICS_APP_GROUP_CLIENT_ID"]; // ADFS 2016 Application Group Client ID
             string applicationGroupSecret = Configuration["DYNAMICS_APP_GROUP_SECRET"]; // ADFS 2016 Application Group Secret
             string serviceAccountUsername = Configuration["DYNAMICS_USERNAME"]; // Service account username
             string serviceAccountPassword = Configuration["DYNAMICS_PASSWORD"]; // Service account password
+            string bypassStsCertValidation = Configuration["BYPASS_STS_CERT_VALIDATION"]; // Bypass STS certificate validation (true/false)
 
-            // API Gateway to NTLM user.  This is used in v8 environments.  Note that the SSG Username and password are not the same as the NTLM user.
-            string ssgUsername = Configuration["SSG_USERNAME"];  // BASIC authentication username
-            string ssgPassword = Configuration["SSG_PASSWORD"];  // BASIC authentication password
-
-            var handler = new HttpClientHandler();
-            handler.ClientCertificateOptions = ClientCertificateOption.Manual;
-            handler.ServerCertificateCustomValidationCallback = 
-            (httpRequestMessage, cert, cetChain, policyErrors) =>
+            if (
+                string.IsNullOrEmpty(adfsOauth2Uri)
+                || string.IsNullOrEmpty(applicationGroupResource)
+                || string.IsNullOrEmpty(applicationGroupClientId)
+                || string.IsNullOrEmpty(applicationGroupSecret)
+                || string.IsNullOrEmpty(serviceAccountUsername)
+                || string.IsNullOrEmpty(serviceAccountPassword)
+            )
             {
-                return true;
-            };
-
-            // fix for problems with TEST STS.
-            var stsClient = new HttpClient(handler);
-
-
-            ServiceClientCredentials serviceClientCredentials = null;
-            if (!string.IsNullOrEmpty(appRegistrationClientId) && !string.IsNullOrEmpty(appRegistrationClientKey) && !string.IsNullOrEmpty(serverAppIdUri) && !string.IsNullOrEmpty(aadTenantId))
-            // Cloud authentication - using an App Registration's client ID, client key.  Add the App Registration to Dynamics as an Application User.
-            {
-                var authenticationContext = new AuthenticationContext(
-                "https://login.windows.net/" + aadTenantId);
-                ClientCredential clientCredential = new ClientCredential(appRegistrationClientId, appRegistrationClientKey);
-                var task = authenticationContext.AcquireTokenAsync(serverAppIdUri, clientCredential);
-                task.Wait();
-                var authenticationResult = task.Result;
-                string token = authenticationResult.CreateAuthorizationHeader().Substring("Bearer ".Length);
-                serviceClientCredentials = new TokenCredentials(token);
+                return null;
             }
-            if (!string.IsNullOrEmpty(adfsOauth2Uri) &&
-                !string.IsNullOrEmpty(applicationGroupResource) &&
-                !string.IsNullOrEmpty(applicationGroupClientId) &&
-                !string.IsNullOrEmpty(applicationGroupSecret) &&
-                !string.IsNullOrEmpty(serviceAccountUsername) &&
-                !string.IsNullOrEmpty(serviceAccountPassword))
-            // ADFS 2016 authentication - using an Application Group Client ID and Secret, plus service account credentials.
-            {                
-                //stsClient.DefaultRequestHeaders.Add("x-client-SKU", "PCL.CoreCLR");
-                //stsClient.DefaultRequestHeaders.Add("x-client-Ver", "5.1.0.0");
-                //stsClient.DefaultRequestHeaders.Add("x-ms-PKeyAuth", "1.0");
 
-                stsClient.DefaultRequestHeaders.Add("client-request-id", Guid.NewGuid().ToString());
-                stsClient.DefaultRequestHeaders.Add("return-client-request-id", "true");
-                stsClient.DefaultRequestHeaders.Add("Accept", "application/json");
-
-                // Construct the body of the request
-                var pairs = new List<KeyValuePair<string, string>>
-                {
-                    new KeyValuePair<string, string>("resource", applicationGroupResource),
-                    new KeyValuePair<string, string>("client_id", applicationGroupClientId),
-                    new KeyValuePair<string, string>("client_secret", applicationGroupSecret),
-                    new KeyValuePair<string, string>("username", serviceAccountUsername),
-                    new KeyValuePair<string, string>("password", serviceAccountPassword),
-                    new KeyValuePair<string, string>("scope", "openid"),
-                    new KeyValuePair<string, string>("response_mode", "form_post"),
-                    new KeyValuePair<string, string>("grant_type", "password")
-                 };
-
-                // This will also set the content type of the request
-                var content = new FormUrlEncodedContent(pairs);
-                // send the request to the ADFS server
-                var _httpResponse = stsClient.PostAsync(adfsOauth2Uri, content).GetAwaiter().GetResult();
-                var _responseContent = _httpResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                // response should be in JSON format.
-                try
-                {
-                    Dictionary<string, string> result = JsonConvert.DeserializeObject<Dictionary<string, string>>(_responseContent);
-                    string token = result["access_token"];
-                    // set the bearer token.
-                    serviceClientCredentials = new TokenCredentials(token);
-                }
-                catch (Exception e)
-                {
-                    throw new InvalidOperationException(e.Message + " " + _responseContent, e);
-                }
-
-            }
-            else if (!string.IsNullOrEmpty(ssgUsername) && !string.IsNullOrEmpty(ssgPassword))
-            // Authenticate using BASIC authentication - used for API Gateways with BASIC authentication.  Add the NTLM user associated with the API gateway entry to Dynamics as a user.            
+            HttpClient stsClient;
+            if (!string.IsNullOrEmpty(bypassStsCertValidation) && bypassStsCertValidation.ToLower() == "true")
             {
-                serviceClientCredentials = new BasicAuthenticationCredentials()
+                var handler = new HttpClientHandler();
+                handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                handler.ServerCertificateCustomValidationCallback = (
+                    httpRequestMessage,
+                    cert,
+                    cetChain,
+                    policyErrors
+                ) =>
                 {
-                    UserName = ssgUsername,
-                    Password = ssgPassword
+                    return true;
                 };
+                stsClient = new HttpClient(handler);
             }
             else
+            {
+                stsClient = new HttpClient();
+            }
+
+            stsClient.DefaultRequestHeaders.Add("client-request-id", Guid.NewGuid().ToString());
+            stsClient.DefaultRequestHeaders.Add("return-client-request-id", "true");
+            stsClient.DefaultRequestHeaders.Add("Accept", "application/json");
+
+            // Construct the body of the request
+            var pairs = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("resource", applicationGroupResource),
+                new KeyValuePair<string, string>("client_id", applicationGroupClientId),
+                new KeyValuePair<string, string>("client_secret", applicationGroupSecret),
+                new KeyValuePair<string, string>("username", serviceAccountUsername),
+                new KeyValuePair<string, string>("password", serviceAccountPassword),
+                new KeyValuePair<string, string>("scope", "openid"),
+                new KeyValuePair<string, string>("response_mode", "form_post"),
+                new KeyValuePair<string, string>("grant_type", "password"),
+            };
+
+            var content = new FormUrlEncodedContent(pairs);
+            var _httpResponse = stsClient.PostAsync(adfsOauth2Uri, content).GetAwaiter().GetResult();
+            var _responseContent = _httpResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+
+            try
+            {
+                Dictionary<string, string> result = JsonConvert.DeserializeObject<Dictionary<string, string>>(
+                    _responseContent
+                );
+                string token = result["access_token"];
+                return new TokenCredentials(token);
+            }
+            catch (Exception e)
+            {
+                throw new Exception(e.Message + " " + _responseContent);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves <see cref="ServiceClientCredentials"/> for the Dynamics client using BASIC authentication.
+        /// </summary>
+        /// <param name="Configuration">The application configuration.</param>
+        /// <returns>ServiceClientCredentials, or null if required configuration is missing.</returns>
+        public static ServiceClientCredentials GetBasicTokenCredentials(IConfiguration Configuration)
+        {
+            // API Gateway to NTLM user.  This is used in v8 environments.  Note that the SSG Username and password are not the same as the NTLM user.
+            string ssgUsername = Configuration["SSG_USERNAME"]; // BASIC authentication username
+            string ssgPassword = Configuration["SSG_PASSWORD"]; // BASIC authentication password
+
+            if (string.IsNullOrEmpty(ssgUsername) || string.IsNullOrEmpty(ssgPassword))
+            {
+                return null;
+            }
+
+            return new BasicAuthenticationCredentials() { UserName = ssgUsername, Password = ssgPassword };
+        }
+
+        /// <summary>
+        /// Retrieves <see cref="ServiceClientCredentials"/> for the Dynamics client.
+        /// Tries Dataverse (cloud), then ADFS on-premise, then BASIC authentication in order.
+        /// </summary>
+        /// <param name="Configuration">The application configuration.</param>
+        /// <returns>ServiceClientCredentials</returns>
+        public static ServiceClientCredentials GetServiceClientCredentials(IConfiguration Configuration)
+        {
+            ServiceClientCredentials serviceClientCredentials =
+                GetDataverseTokenCredentials(Configuration)
+                ?? GetOnPremTokenCredentials(Configuration)
+                ?? GetBasicTokenCredentials(Configuration);
+
+            if (serviceClientCredentials == null)
             {
                 throw new InvalidOperationException("No configured connection to Dynamics.");
             }
@@ -132,14 +190,18 @@ namespace Gov.Jag.Spice.Interfaces
 
             if (string.IsNullOrEmpty(dynamicsOdataUri))
             {
-                throw new ArgumentException("Configuration setting DYNAMICS_ODATA_URI is blank.", nameof(Configuration));
+                throw new ArgumentException(
+                    "Configuration setting DYNAMICS_ODATA_URI is blank.",
+                    nameof(Configuration)
+                );
             }
 
             ServiceClientCredentials serviceClientCredentials = GetServiceClientCredentials(Configuration);
 
             IDynamicsClient client = new DynamicsClient(new Uri(dynamicsOdataUri), serviceClientCredentials);
 
-            // set the native client URI.  This is required if you have a reverse proxy or IFD in place and the native URI is different from your access URI.
+            // Set the native client URI. This is required if you have a reverse proxy or IFD in place and the native
+            // URI is different from your access URI.
             if (string.IsNullOrEmpty(Configuration["DYNAMICS_NATIVE_ODATA_URI"]))
             {
                 client.NativeBaseUri = new Uri(Configuration["DYNAMICS_ODATA_URI"]);

--- a/spice-carla-sync-service/Startup.cs
+++ b/spice-carla-sync-service/Startup.cs
@@ -169,13 +169,11 @@ namespace Gov.Jag.Spice.CarlaSync
             {
                 try
                 {
-                    Console.WriteLine($"[Request] {context.Request.Method} {context.Request.Path} from {context.Connection.RemoteIpAddress}");
                     logger.LogInformation("[Request] {Method} {Path} from {RemoteIp}", 
                         context.Request.Method, 
                         context.Request.Path, 
                         context.Connection.RemoteIpAddress);
                     await next();
-                    Console.WriteLine($"[Response] {context.Request.Method} {context.Request.Path} returned {context.Response.StatusCode}");
                     logger.LogInformation("[Response] {Method} {Path} returned {StatusCode}", 
                         context.Request.Method, 
                         context.Request.Path, 
@@ -183,8 +181,8 @@ namespace Gov.Jag.Spice.CarlaSync
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MIDDLEWARE EXCEPTION] {ex.GetType().Name}: {ex.Message}");
-                    Console.WriteLine($"[MIDDLEWARE EXCEPTION] Stack: {ex.StackTrace}");
+                    logger.LogError($"[MIDDLEWARE EXCEPTION] {ex.GetType().Name}: {ex.Message}");
+                    logger.LogError($"[MIDDLEWARE EXCEPTION] Stack: {ex.StackTrace}");
                     logger.LogError(ex, "[MIDDLEWARE EXCEPTION] Unhandled exception in request pipeline");
                     context.Response.StatusCode = 500;
                     await context.Response.WriteAsync(ex.Message);


### PR DESCRIPTION
## Ticket

https://jira.justice.gov.bc.ca/browse/SDCM-282
https://jira.justice.gov.bc.ca/browse/SDCM-283

## Changes

Update dynamics auth code.

## OpenShift

New cloud secrets for both `spd-spice-sync` and `spd-ess-portal`:
```
  "DYNAMICS_AAD_TENANT_ID": "",
  "DYNAMICS_SERVER_APP_ID_URI": "https://spd-spice-dev.api.crm3.dynamics.com",
  "DYNAMICS_APP_REG_CLIENT_ID": "",
  "DYNAMICS_APP_REG_CLIENT_KEY": "",
  "DYNAMICS_NATIVE_ODATA_URI": "https://spd-spice-dev.api.crm3.dynamics.com/api/data/v9.2/",
  "DYNAMICS_ODATA_URI": "https://spd-spice-dev.api.crm3.dynamics.com/api/data/v9.2/",
```

New SharePoint cloud secrets for `spd-ess-portal`:
```
  "SHAREPOINT_TYPE": "Cloud",
  "SHAREPOINT_AAD_TENANTID": "",
  "SHAREPOINT_CLIENT_ID": "",
  "SHAREPOINT_CLIENT_SECRET": "",
  "SHAREPOINT_ODATA_URI_CLOUD": "https://bcgov.sharepoint.com/sites/spd-spice-dev",
  ```
  
  See myself or Mano for the actual ids and secret values.